### PR TITLE
Add peer dependencies for react and react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     "tape": "^4.5.1",
     "webpack": "^1.13.0"
   },
+  "peerDependencies": {
+    "react": ">=0.14.2",
+    "react-dom": ">=0.14.2"
+  },
   "keywords": [
     "templates",
     "react-templates",


### PR DESCRIPTION
I used 0.14.2 as a base because that was the version of react and react-dom used before upgrading.
